### PR TITLE
feat: skipping files based on regex and fixing parsing of args

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ The command line version is more powerful as you can add flags and a path, see t
   - You might need to provide permissions, this program is not a virus. On Unix, run `chmod +x renpy-graphviz*`.
 - `renpy-graphviz.png` should appear, **enjoy**!
 
+Use the boolean flags only in `-flag=value` format, not in `-flag value ` format, e.g. use `./renpy-graphviz -open=false`.
+
 ### Go library
 
 ```cmd

--- a/config.go
+++ b/config.go
@@ -51,6 +51,9 @@ silent = false # default: false
 # Debug mode
 debug = false # default: false
 
+# Regex for skipping files
+skip-files = "" # default: ""
+
 ### You can edit ↑ above ↑
 
 ### HOW TO USE THE PROGRAM? ###

--- a/main.go
+++ b/main.go
@@ -13,7 +13,7 @@ import (
 func main() {
 	path, options := PlugCLI()
 
-	content := parser.GetRenpyContent(path)
+	content := parser.GetRenpyContent(path, options)
 
 	graph, err := parser.Graph(content, options)
 	if err != nil {

--- a/parser/examples_graphs_test.go
+++ b/parser/examples_graphs_test.go
@@ -194,7 +194,7 @@ digraph  {
 	r := strings.NewReplacer(" ", "", "\t", "", "\n", "")
 	for _, tc := range testCases {
 		t.Run(tc.pathToScript, func(t *testing.T) {
-			renpyLines := GetRenpyContent(tc.pathToScript)
+			renpyLines := GetRenpyContent(tc.pathToScript, tc.options)
 			graphResult, err := Graph(renpyLines, tc.options)
 			require.NoError(t, err)
 

--- a/parser/filehandling.go
+++ b/parser/filehandling.go
@@ -11,8 +11,8 @@ import (
 
 // GetRenpyContent opens all renpy files and transform them into a string list
 // 1 line of script = 1 list element
-func GetRenpyContent(rootPath string) []string {
-	files, err := walkMatch(rootPath, "*.rpy")
+func GetRenpyContent(rootPath string, options RenpyGraphOptions) []string {
+	files, err := walkMatch(rootPath, "*.rpy", options.SkipFilesRegex)
 	if err != nil {
 		log.Fatalf("failed to find root folder: %s", err)
 	}
@@ -59,13 +59,21 @@ func GetRenpyContent(rootPath string) []string {
 	return fileTextLines
 }
 
-func walkMatch(root, pattern string) ([]string, error) {
+func walkMatch(root, pattern string, skipPattern string) ([]string, error) {
 	var matches []string
 	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}
 		if info.IsDir() {
+			return nil
+		}
+		if filepath.Base(path) == "test.rpy" {
+			println("foudn test rpy")
+		}
+		if matched, err := filepath.Match(skipPattern, filepath.Base(path)); err != nil {
+			return err
+		} else if matched {
 			return nil
 		}
 		if matched, err := filepath.Match(pattern, filepath.Base(path)); err != nil {

--- a/parser/filehandling_test.go
+++ b/parser/filehandling_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestGetRenpyContent(t *testing.T) {
-	result := GetRenpyContent("../testCases/simple")
+	result := GetRenpyContent("../testCases/simple", RenpyGraphOptions{})
 
 	expected := strings.Split(`label start:
     "Is my VN simple ?"

--- a/parser/graph.go
+++ b/parser/graph.go
@@ -31,13 +31,14 @@ type RenpyGraph struct {
 
 // RenpyGraphOptions are options that can be set to make a more customizable graph
 type RenpyGraphOptions struct {
-	ShowEdgesLabels   bool // Show Labels on Edges? Can be unreadable but there is more information
-	ShowAtoms         bool // Show lonely nodes ? Might be useful but useless most of the time - and it avoids writing IGNORE tag everywhere
-	ShowScreens       bool // Show screens ?
-	ShowNestedScreens bool // Show nested screens (`use` keyword)
-	Silent            bool // Display .dot graph in the stdout
-	OpenFile          bool // Open the image in the default image viewer or not ?
-	FullDebug         bool // Show all lines and updates
+	ShowEdgesLabels   bool   // Show Labels on Edges? Can be unreadable but there is more information
+	ShowAtoms         bool   // Show lonely nodes ? Might be useful but useless most of the time - and it avoids writing IGNORE tag everywhere
+	ShowScreens       bool   // Show screens ?
+	ShowNestedScreens bool   // Show nested screens (`use` keyword)
+	Silent            bool   // Display .dot graph in the stdout
+	OpenFile          bool   // Open the image in the default image viewer or not ?
+	FullDebug         bool   // Show all lines and updates
+	SkipFilesRegex    string // Skip all files matching this regex
 }
 
 // NewGraph creates an empty graph

--- a/parser/perf_test.go
+++ b/parser/perf_test.go
@@ -6,7 +6,7 @@ import (
 
 func BenchmarkGetContent(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		GetRenpyContent("../testCases/complex")
+		GetRenpyContent("../testCases/complex", RenpyGraphOptions{})
 	}
 }
 
@@ -14,7 +14,7 @@ var graph RenpyGraph
 
 func BenchmarkGraph(b *testing.B) {
 	var g RenpyGraph
-	renpyLines := GetRenpyContent("../testCases/complex")
+	renpyLines := GetRenpyContent("../testCases/complex", RenpyGraphOptions{})
 	for i := 0; i < b.N; i++ {
 		g, _ = Graph(renpyLines, RenpyGraphOptions{})
 	}


### PR DESCRIPTION
This PR fixes #81 and adds a new flag which lets you skip some files based on regex. Sometimes people keep testing files in the game and I don't want to delete them when running the code, I want to skip them by passing some argument to the program 
There are multiple ways to do it, but I feel like using regex is the simplest, because you can skip arbitrary amount of files just by passing single regex.

And regarding the boolean flags, the only way how to pass them false value is using `=`, which is non-intuitive, so I added example to the readme. See the docs: https://pkg.go.dev/flag which say `-flag x  // non-boolean flags only`

I have tested it locally and it works well.